### PR TITLE
New locate_by type: LOCATION_DISTRICT

### DIFF
--- a/call_server/campaign/constants.py
+++ b/call_server/campaign/constants.py
@@ -58,11 +58,13 @@ SEGMENT_BY_CHOICES = (
 LOCATION_POSTAL = 'postal'
 LOCATION_ADDRESS = 'address'
 LOCATION_LATLON = 'latlon'
+LOCATION_DISTRICT = 'district'
 LOCATION_CHOICES = (
     ('', 'None'),
     (LOCATION_POSTAL, 'ZIP / Postal Code'),
     (LOCATION_ADDRESS, 'Street Address'),
-    (LOCATION_LATLON, 'Lat / Lon')
+    (LOCATION_LATLON, 'Lat / Lon'),
+    (LOCATION_DISTRICT, 'District')
 )
 
 ORDER_IN_ORDER = 'in-order'

--- a/call_server/political_data/countries/us.py
+++ b/call_server/political_data/countries/us.py
@@ -107,27 +107,37 @@ class USData(DataProvider):
     def get_uid(self, key):
         return self.cache.get(key) or {}
 
-    def locate_targets(self, zipcode, chambers=TARGET_CHAMBER_BOTH, order=ORDER_IN_ORDER):
-        """ Find all congressional targets for a zipcode, crossing state boundaries if necessary.
+    def locate_targets(self, state=None, district=None, zipcode=None, chambers=TARGET_CHAMBER_BOTH, order=ORDER_IN_ORDER):
+        """ Find all congressional targets for state/district (or just zipcode).
         Returns a list of cached bioguide keys in specified order.
         """
 
-        districts = self.cache.get(self.KEY_ZIPCODE.format(zipcode=zipcode))
-        if not districts:
-            return None
-
-        states = set(d['state'] for d in districts)  # yes, there are zipcodes that cross states
-        if not states:
-            return None
-
         senators = []
         house_reps = []
-        for state in states:
+        if zipcode:
+            districts = self.cache.get(self.KEY_ZIPCODE.format(zipcode=zipcode))
+            if not districts:
+                return None
+
+            states = set(d['state'] for d in districts)  # there are zipcodes that cross states
+            if not states:
+                return None
+
+            for state in states:
+                for senator in self.get_senators(state):
+                    senators.append(self.KEY_BIOGUIDE.format(**senator))
+
+            for d in districts:
+                rep = self.get_house_member(d['state'], d['house_district'])[0]
+                house_reps.append(self.KEY_BIOGUIDE.format(**rep))
+        elif state and district:
             for senator in self.get_senators(state):
                 senators.append(self.KEY_BIOGUIDE.format(**senator))
-        for d in districts:
-            rep = self.get_house_member(d['state'], d['house_district'])[0]
+
+            rep = self.get_house_member(state, district)[0]
             house_reps.append(self.KEY_BIOGUIDE.format(**rep))
+        else:
+            raise ValueError("state and district, or zipcode, must be provided")
 
         targets = []
         if chambers == TARGET_CHAMBER_UPPER:

--- a/call_server/political_data/lookup.py
+++ b/call_server/political_data/lookup.py
@@ -1,6 +1,6 @@
 from ..campaign.constants import (TYPE_CONGRESS, TYPE_STATE, TYPE_EXECUTIVE,
     TARGET_EXECUTIVE, TARGET_CHAMBER_BOTH, TARGET_CHAMBER_UPPER, TARGET_CHAMBER_LOWER,
-    LOCATION_POSTAL, LOCATION_ADDRESS, LOCATION_LATLON,
+    LOCATION_POSTAL, LOCATION_ADDRESS, LOCATION_DISTRICT, LOCATION_LATLON,
     ORDER_IN_ORDER, ORDER_SHUFFLE, ORDER_UPPER_FIRST, ORDER_LOWER_FIRST)
 
 from ..extensions import cache
@@ -25,7 +25,12 @@ def locate_targets(location, campaign):
 
     if campaign.campaign_type == TYPE_CONGRESS:
         data = COUNTRY_DATA['US']
-        if campaign.locate_by == LOCATION_POSTAL:
+        if campaign.locate_by == LOCATION_DISTRICT:
+            (state, district) = location.split("-")
+            return data.locate_targets(state=state, district=district,
+                chambers=campaign.campaign_subtype,
+                order=campaign.target_ordering)
+        elif campaign.locate_by == LOCATION_POSTAL:
             return data.locate_targets(zipcode=location,
                 chambers=campaign.campaign_subtype,
                 order=campaign.target_ordering)


### PR DESCRIPTION
This branch adds a new locate_by type, LOCATION_DISTRICT.

It allows userLocation to be given as a state-district string. For incoming calls, campaigns configured as LOCATE_DISTRICT will fall back to asking for zip code and looking up representatives through the ztca->district mapping.

This is introduced as a way of future proofing the tool against disruptions to the Sunlight Congress api. Various geocoding services (e.g. SmartyStreets, geocod.io) will include the congressional district as apart of their address data, so with LOCATION_DISTRICT call-power clients can connect to the correct representative without relying on Sunlight Congress.
