### PR TITLE
Bump six to version 1.10.0 from 1.5.2

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -35,7 +35,7 @@ python-dateutil==2.2
 python-mimeparse==0.1.4
 pytz==2013.9
 requests==2.2.1
-six==1.5.2
+six==1.10.0
 speaklater==1.3
 sunlight==1.2.9
 twilio==3.6.5


### PR DESCRIPTION
This caused a failure when building a docker image. An existing package
required six>=1.10.0, but the requirements.txt was frozen on an earlier
version of six.

The docker image builds correctly with this patch.